### PR TITLE
Stackdriver metrics in native mode

### DIFF
--- a/integration-tests/micrometer-native/src/test/java/io/quarkiverse/it/micrometer/native_mode/NativeMeterRegistriesIT.java
+++ b/integration-tests/micrometer-native/src/test/java/io/quarkiverse/it/micrometer/native_mode/NativeMeterRegistriesIT.java
@@ -26,13 +26,13 @@ class NativeMeterRegistriesIT extends NativeMeterRegistriesTest {
 
         List<Object> registries = response.jsonPath().getList("$");
         MatcherAssert.assertThat(registries, Matchers.containsInAnyOrder(
-                "io.micrometer.datadog.DatadogMeterRegistry"));
+                "io.micrometer.datadog.DatadogMeterRegistry",
+                "io.micrometer.stackdriver.StackdriverMeterRegistry"));
 
         MatcherAssert.assertThat(registries, Matchers.not(Matchers.containsInAnyOrder(
                 "io.micrometer.azuremonitor.AzureMonitorMeterRegistry",
                 "io.micrometer.jmx.JmxMeterRegistry",
                 "io.micrometer.signalfx.SignalFxMeterRegistry",
-                "io.micrometer.stackdriver.StackdriverMeterRegistry",
                 "io.micrometer.statsd.StatsdMeterRegistry")));
     }
 }

--- a/micrometer-registry-stackdriver/deployment/src/main/java/io/quarkiverse/micrometer/registry/stackdriver/deployment/StackdriverRegistryProcessor.java
+++ b/micrometer-registry-stackdriver/deployment/src/main/java/io/quarkiverse/micrometer/registry/stackdriver/deployment/StackdriverRegistryProcessor.java
@@ -10,7 +10,6 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
-import io.quarkus.deployment.pkg.steps.NativeBuild;
 import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
 import io.quarkus.micrometer.runtime.MicrometerRecorder;
 import io.quarkus.micrometer.runtime.config.MicrometerConfig;
@@ -35,14 +34,7 @@ public class StackdriverRegistryProcessor {
         }
     }
 
-    @BuildStep(onlyIf = { NativeBuild.class, StackdriverEnabled.class })
-    public MicrometerRegistryProviderBuildItem nativeModeNotSupported() {
-        log.info("The Stackdriver meter registry does not support running in native mode.");
-        return null;
-    }
-
-    /** Stackdriver does not work with GraalVM */
-    @BuildStep(onlyIf = StackdriverEnabled.class, onlyIfNot = NativeBuild.class)
+    @BuildStep(onlyIf = StackdriverEnabled.class)
     public MicrometerRegistryProviderBuildItem createStackdriverRegistry(CombinedIndexBuildItem index,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
 

--- a/micrometer-registry-stackdriver/runtime/pom.xml
+++ b/micrometer-registry-stackdriver/runtime/pom.xml
@@ -16,8 +16,20 @@
             <artifactId>quarkus-micrometer</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-stackdriver</artifactId>
+            <exclusions>
+                <!-- We exclude the gprc library as it is provided by the quarkiverse extension -->
+                <exclusion>
+                    <groupId>com.google.api</groupId>
+                    <artifactId>gax-grpc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Use google cloud services quarkiverse extension to fix netty/grpc usage in Micrometer's Stackdriver registry
```
<dependency>
    <groupId>io.quarkiverse.googlecloudservices</groupId>
    <artifactId>quarkus-google-cloud-common-grpc</artifactId>
    <version>0.4.0</version>
</dependency>
```

Resolves quarkusio/quarkus#13349