### PR TITLE
Remove usage of the now defunct native-image mojo

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -85,21 +85,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
This is causing a CI failure with Quarkus master. Setting the `quarkus.package.type` property to `native` is enough.