### PR TITLE
2.2.2 Release for 2.2.2.Final

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus Micrometer Registry Extensions
 release:
-  current-version: 2.1.0
+  current-version: 2.2.2
   next-version: 299-SNAPSHOT
   attribute: true


### PR DESCRIPTION
Release works with 2.1.x and 2.2.x of Quarkus.

Will not work against Quarkus 2.3.x/main due to refactoring of vertx-* extensions.
