### PR TITLE
Move to quarkus-reactive-routes

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 2.3.0.Final
+:quarkus-version: 2.4.1.Final
 :quarkus-micrometer-registry-version: 2.3.0
 

--- a/integration-tests/micrometer-jmx/pom.xml
+++ b/integration-tests/micrometer-jmx/pom.xml
@@ -24,10 +24,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Do not use Resteasy! Deliberately focused on vertx-web alone -->
+        <!-- Do not use Resteasy! Deliberately focused on quarkus-reactive-routes alone -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
 
         <dependency>

--- a/integration-tests/micrometer-native/pom.xml
+++ b/integration-tests/micrometer-native/pom.xml
@@ -20,7 +20,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Depending on vertx-web is causing issues when building with Quarkus main
(Ecosystem CI) as it downloads old snapshots from our snapshots
repository.