### PR TITLE
Release 2.11.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus Micrometer Registry Extensions
 release:
-  current-version: 2.10.0
+  current-version: 2.11.0
   next-version: 299-SNAPSHOT
   attribute: true


### PR DESCRIPTION
Combination of Quarkus 2.11.0 and grpc updates in micrometer's stackdriver library:

- Bump quarkus-google-cloud-services-bom from 1.1.1 to 1.2.0 (#188)
- Bump quarkus.version from 2.10.2.Final to 2.11.0.Final (#190)