### PR TITLE
Release 2.11.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus Micrometer Registry Extensions
 release:
-  current-version: 2.10.0
+  current-version: 2.11.0
   next-version: 299-SNAPSHOT
   attribute: true

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 2.10.0.Final
-:quarkus-micrometer-registry-version: 2.10.0
+:quarkus-version: 2.11.0.Final
+:quarkus-micrometer-registry-version: 2.11.0
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-azuremonitor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-azuremonitor.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-azuremonitor
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_
 --
 Support for export to AzureMonitor. 
  Support for AzureMonitor will be enabled if Micrometer support is enabled, the Azure Monitor registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_AZUREMONITOR_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_
 --
 By default, this extension will create a AzureMonitor MeterRegistry instance. 
  Use this attribute to veto the creation of the default AzureMonitor MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_AZUREMONITOR_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -53,6 +59,8 @@ Use this attribute to selectively disable publication of metrics in some environ
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_AZUREMONITOR+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-datadog.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-datadog.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-datadog
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quark
 --
 Support for export to Datadog 
  Support for Datadog will be enabled if Micrometer support is enabled, the Datadog registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_DATADOG_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quark
 --
 By default, this extension will create a Datadog MeterRegistry instance. 
  Use this attribute to veto the creation of the default Datadog MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_DATADOG_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -56,6 +62,8 @@ Use this attribute to selectively disable publication of metrics in some environ
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_DATADOG+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-graphite.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-graphite.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-graphite
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quar
 --
 Support for export to Graphite. 
  Support for Graphite will be enabled if Micrometer support is enabled, the Graphite registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_GRAPHITE_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quar
 --
 By default, this extension will create a Graphite MeterRegistry instance. 
  Use this attribute to veto the creation of the default Graphite MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_GRAPHITE_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -79,6 +85,8 @@ Defaults to 1 minute.
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_GRAPHITE+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-influx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-influx.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-influx
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarku
 --
 Support for export to InfluxDB. 
  Support for InfluxDB will be enabled if Micrometer support is enabled, the InfluxDB registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_INFLUX_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarku
 --
 By default, this extension will create a InfluxDB MeterRegistry instance. 
  Use this attribute to veto the creation of the default InfluxDB MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_INFLUX_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -74,6 +80,8 @@ Other Micrometer configuration attributes can also be specified.
 As mentioned in the Micrometer InfluxDB documentation, if you want to customize the metrics
 sink, do so by providing your own `InfluxDBMeterRegistry` instance using a CDI `@Produces`
 method.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_INFLUX+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-jmx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-jmx.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-jmx
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus.m
 --
 Support for export to JMX 
  Support for JMX will be enabled if Micrometer support is enabled, the JMX registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_JMX_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus.m
 --
 By default, this extension will create a JMX MeterRegistry instance. 
  Use this attribute to veto the creation of the default JMX MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_JMX_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -36,6 +42,8 @@ JMX registry configuration properties.
 
 A property source for configuration of the JMX MeterRegistry,
 see https://micrometer.io/docs/registry/jmx.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_JMX+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic-telemetry.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic-telemetry.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-newrelic-telemetry
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-tele
 --
 Support for export to New Relic 
  Support for New Relic will be enabled if Micrometer support is enabled, the New Relic registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_TELEMETRY_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-tele
 --
 By default, this extension will create a New Relic MeterRegistry instance. 
  Use this attribute to veto the creation of the default New Relic MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_TELEMETRY_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -59,6 +65,8 @@ https://github.com/newrelic/micrometer-registry-newrelic/blob/main/src/main/java
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_TELEMETRY+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-newrelic
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quar
 --
 Support for export to New Relic 
  Support for New Relic will be enabled if Micrometer support is enabled, the New Relic registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quar
 --
 By default, this extension will create a New Relic MeterRegistry instance. 
  Use this attribute to veto the creation of the default New Relic MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -59,6 +65,8 @@ Use this attribute to selectively disable publication of metrics in some environ
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-otlp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-otlp.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-otlp
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus.
 --
 Support for export to OTLP. 
  Support for OTLP will be enabled if Micrometer support is enabled, the OTLP registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_OTLP_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus.
 --
 By default, this extension will create a OTLP MeterRegistry instance. 
  Use this attribute to veto the creation of the default OTLP MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_OTLP_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -55,6 +61,8 @@ build the resource attributes.
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_OTLP+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-signalfx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-signalfx.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-signalfx
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quar
 --
 Support for export to SignalFx. 
  Support for SignalFx will be enabled if Micrometer support is enabled, the SignalFx registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_SIGNALFX_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quar
 --
 By default, this extension will create a SignalFx MeterRegistry instance. 
  Use this attribute to veto the creation of the default SignalFx MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_SIGNALFX_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -64,6 +70,8 @@ Use this attribute to selectively disable publication of metrics in some environ
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_SIGNALFX+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-stackdriver.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-stackdriver.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-stackdriver
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -27,6 +29,8 @@ for native builds.
 <p>
 See https://github.com/grpc/grpc-java/issues/5460
 ====
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STACKDRIVER_ENABLED+++`
 --|boolean 
 |
 
@@ -37,6 +41,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_q
 --
 By default, this extension will create a Stackdriver MeterRegistry instance. 
  Use this attribute to veto the creation of the default Stackdriver MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STACKDRIVER_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -69,6 +75,8 @@ Use this attribute to selectively disable publication of metrics in some environ
 !===
 
 Other Micrometer configuration attributes can also be specified.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STACKDRIVER+++`
 --|`Map<String,String>` 
 |
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-statsd.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-statsd.adoc
@@ -1,3 +1,5 @@
+
+:summaryTableId: quarkus-micrometer-export-statsd
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -14,6 +16,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarku
 --
 Support for export to StatsD. 
  Support for StatsD will be enabled if Micrometer support is enabled, the Statsd registry extension is enabled and either this value is true, or this value is unset and `quarkus.micrometer.registry-enabled-default` is true.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STATSD_ENABLED+++`
 --|boolean 
 |
 
@@ -24,6 +28,8 @@ a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarku
 --
 By default, this extension will create a StatsD MeterRegistry instance. 
  Use this attribute to veto the creation of the default StatsD MeterRegistry.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STATSD_DEFAULT_REGISTRY+++`
 --|boolean 
 |`true`
 
@@ -73,6 +79,8 @@ Other Micrometer configuration attributes can also be specified.
 As mentioned in the Micrometer StatsD documentation, if you want to customize the metrics
 sink, do so by providing your own `StatsDMeterRegistry` instance using a CDI `@Produces`
 method.
+
+Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STATSD+++`
 --|`Map<String,String>` 
 |
 


### PR DESCRIPTION
Combination of Quarkus 2.11.0 and grpc updates in micrometer's stackdriver library:

- Bump quarkus-google-cloud-services-bom from 1.1.1 to 1.2.0 (#188)
- Bump quarkus.version from 2.10.2.Final to 2.11.0.Final (#190)