### PR TITLE
Correct dead links

### DIFF
--- a/micrometer-registry-azure-monitor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-azure-monitor/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-datadog/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-datadog/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-graphite/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-graphite/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "graphite"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-influx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-influx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,7 +7,7 @@ metadata:
   - "influx"
   - "influxdb"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-jmx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-jmx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-newrelic-telemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-newrelic-telemetry/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-newrelic/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-newrelic/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-otlp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-otlp/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "otlp"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-signalfx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-signalfx/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-stackdriver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-stackdriver/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"

--- a/micrometer-registry-statsd/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-statsd/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   - "metric"
   - "prometheus"
   - "monitoring"
-  guide: "https://quarkus.io/guides/micrometer-metrics"
+  guide: "https://quarkus.io/guides/micrometer"
   categories:
   - "observability"
   status: "experimental"


### PR DESCRIPTION
I spotted that the extension yamls here link to https://quarkus.io/guides/micrometer-metrics, but that page doesn't exist. There's a page at https://quarkus.io/guides/micrometer titled 'Micrometer Metrics', so I'm assuming that's where the links should point. 

(Alternatively, the guide could be given a different URL, but my guess is that is more invasive.)