### PR TITLE
Replace usage of @AlternativePriority with @Alternative + @Priority

### DIFF
--- a/micrometer-registry-otlp/runtime/src/main/java/io/quarkiverse/micrometer/registry/otlp/ConditionalRegistryProducer.java
+++ b/micrometer-registry-otlp/runtime/src/main/java/io/quarkiverse/micrometer/registry/otlp/ConditionalRegistryProducer.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.micrometer.registry.otlp;
 
+import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 import javax.interceptor.Interceptor;
@@ -7,7 +8,7 @@ import javax.interceptor.Interceptor;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.registry.otlp.OtlpConfig;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
-import io.quarkus.arc.AlternativePriority;
+import io.quarkus.arc.Priority;
 
 @Singleton
 public class ConditionalRegistryProducer {
@@ -17,7 +18,8 @@ public class ConditionalRegistryProducer {
      */
     @Produces
     @Singleton
-    @AlternativePriority(Interceptor.Priority.APPLICATION + 100)
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION + 100)
     public OtlpMeterRegistry registry(OtlpConfig config,
             Clock clock) {
         return new OtlpMeterRegistry(config, clock);


### PR DESCRIPTION
The `@AlternativePriority` annotation has been deprecated since Quarkus 2.6 and is being removed in Quarkus 3.0 (see https://github.com/quarkusio/quarkus/issues/30963 and https://github.com/quarkusio/quarkus/pull/31033). The replacement is a combination of `@Alternative` and `@Priority`.

There are in fact _two_ `@Priority` annotations to choose from:

- `javax.annotation.Priority`
- `io.quarkus.arc.Priority`

The `javax.annotation.Priority` annotation cannot be put on methods, and its `jakarta.annotation.Priority` counterpart can only be put on methods since Common Annotations 2.1 (Jakarta EE 10).

Therefore, this commit uses `io.quarkus.arc.Priority`, even though it is getting deprecated in Quarkus 3.0, to allow maintaining Quarkus 2.x and 3.x compatibility in this project through mechanical transformation. If that is not necessary and this project moves to Quarkus 3.x unconditionally, using `jakarta.annotation.Priority` would be a better choice.