### PR TITLE
Release 2.13

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus Micrometer Registry Extensions
 release:
-  current-version: 2.12.0
+  current-version: 2.13.0
   next-version: 299-SNAPSHOT
   attribute: true

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 2.14.1.Final
-:quarkus-micrometer-registry-version: 2.12.0
+:quarkus-version: 2.16.5.Final
+:quarkus-micrometer-registry-version: 2.13.0
 


### PR DESCRIPTION
Last scheduled release of the Quarkus 2x line.
This is done in preparation for the Quarkus 3 migration work.