### PR TITLE
Bump build to JDK 17

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -18,7 +18,7 @@ defaults:
 env:
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #


### PR DESCRIPTION
- Required because of https://github.com/quarkusio/quarkus/pull/37335. See https://quarkus.io/blog/jdk-17 for more details