### PR TITLE
Bump to Quarkus 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Build with Maven

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.2.4.Final
+:quarkus-version: 3.7.1
 :quarkus-micrometer-registry-version: 3.2.4
 

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-azuremonitor.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-azuremonitor.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-azuremonitor_configuration]]link:#quarkus-micromet
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.get-enabled]]`link:#quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.get-enabled[quarkus.micrometer.export.azuremonitor.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_AZUREMONITOR_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_AZUREMONITOR_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.enabled]]`link:#quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.enabled[quarkus.micrometer.export.azuremonitor.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-enabled]]`link:#quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-enabled[quarkus.micrometer.export.azuremonitor.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.default-registry]]`link:#quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor.default-registry[quarkus.micrometer.export.azuremonitor.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-default-registry]]`link:#quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-default-registry[quarkus.micrometer.export.azuremonitor.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor-azuremonitor]]`link:#quarkus-micrometer-export-azuremonitor_quarkus.micrometer.export.azuremonitor-azuremonitor[quarkus.micrometer.export.azuremonitor]`
+a| [[quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-azuremonitor]]`link:#quarkus-micrometer-export-azuremonitor_quarkus-micrometer-export-azuremonitor-azuremonitor[quarkus.micrometer.export.azuremonitor]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-datadog.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-datadog.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-datadog_configuration]]link:#quarkus-micrometer-ex
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.get-enabled]]`link:#quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.get-enabled[quarkus.micrometer.export.datadog.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_DATADOG_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_DATADOG_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.enabled]]`link:#quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.enabled[quarkus.micrometer.export.datadog.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-enabled]]`link:#quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-enabled[quarkus.micrometer.export.datadog.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.default-registry]]`link:#quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog.default-registry[quarkus.micrometer.export.datadog.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-default-registry]]`link:#quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-default-registry[quarkus.micrometer.export.datadog.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog-datadog]]`link:#quarkus-micrometer-export-datadog_quarkus.micrometer.export.datadog-datadog[quarkus.micrometer.export.datadog]`
+a| [[quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-datadog]]`link:#quarkus-micrometer-export-datadog_quarkus-micrometer-export-datadog-datadog[quarkus.micrometer.export.datadog]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-graphite.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-graphite.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-graphite_configuration]]link:#quarkus-micrometer-e
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.get-enabled]]`link:#quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.get-enabled[quarkus.micrometer.export.graphite.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_GRAPHITE_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_GRAPHITE_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.enabled]]`link:#quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.enabled[quarkus.micrometer.export.graphite.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-enabled]]`link:#quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-enabled[quarkus.micrometer.export.graphite.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.default-registry]]`link:#quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite.default-registry[quarkus.micrometer.export.graphite.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-default-registry]]`link:#quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-default-registry[quarkus.micrometer.export.graphite.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite-graphite]]`link:#quarkus-micrometer-export-graphite_quarkus.micrometer.export.graphite-graphite[quarkus.micrometer.export.graphite]`
+a| [[quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-graphite]]`link:#quarkus-micrometer-export-graphite_quarkus-micrometer-export-graphite-graphite[quarkus.micrometer.export.graphite]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-influx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-influx.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-influx_configuration]]link:#quarkus-micrometer-exp
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.get-enabled]]`link:#quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.get-enabled[quarkus.micrometer.export.influx.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_INFLUX_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_INFLUX_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.enabled]]`link:#quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.enabled[quarkus.micrometer.export.influx.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-enabled]]`link:#quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-enabled[quarkus.micrometer.export.influx.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.default-registry]]`link:#quarkus-micrometer-export-influx_quarkus.micrometer.export.influx.default-registry[quarkus.micrometer.export.influx.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-default-registry]]`link:#quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-default-registry[quarkus.micrometer.export.influx.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-influx_quarkus.micrometer.export.influx-influxdb]]`link:#quarkus-micrometer-export-influx_quarkus.micrometer.export.influx-influxdb[quarkus.micrometer.export.influx]`
+a| [[quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-influxdb]]`link:#quarkus-micrometer-export-influx_quarkus-micrometer-export-influx-influxdb[quarkus.micrometer.export.influx]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-jmx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-jmx.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-jmx_configuration]]link:#quarkus-micrometer-export
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.get-enabled]]`link:#quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.get-enabled[quarkus.micrometer.export.jmx.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_JMX_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_JMX_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.enabled]]`link:#quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.enabled[quarkus.micrometer.export.jmx.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-enabled]]`link:#quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-enabled[quarkus.micrometer.export.jmx.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.default-registry]]`link:#quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx.default-registry[quarkus.micrometer.export.jmx.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-default-registry]]`link:#quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-default-registry[quarkus.micrometer.export.jmx.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx-jmx]]`link:#quarkus-micrometer-export-jmx_quarkus.micrometer.export.jmx-jmx[quarkus.micrometer.export.jmx]`
+a| [[quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-jmx]]`link:#quarkus-micrometer-export-jmx_quarkus-micrometer-export-jmx-jmx[quarkus.micrometer.export.jmx]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic-telemetry.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic-telemetry.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-newrelic-telemetry_configuration]]link:#quarkus-mi
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.get-enabled]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.get-enabled[quarkus.micrometer.export.newrelic.telemetry.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_TELEMETRY_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_TELEMETRY_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.enabled]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.enabled[quarkus.micrometer.export.newrelic.telemetry.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-enabled]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-enabled[quarkus.micrometer.export.newrelic.telemetry.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.default-registry]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry.default-registry[quarkus.micrometer.export.newrelic.telemetry.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-default-registry]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-default-registry[quarkus.micrometer.export.newrelic.telemetry.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry-newrelic]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus.micrometer.export.newrelic.telemetry-newrelic[quarkus.micrometer.export.newrelic.telemetry]`
+a| [[quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-newrelic]]`link:#quarkus-micrometer-export-newrelic-telemetry_quarkus-micrometer-export-newrelic-telemetry-newrelic[quarkus.micrometer.export.newrelic.telemetry]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-newrelic.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-newrelic_configuration]]link:#quarkus-micrometer-e
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.get-enabled]]`link:#quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.get-enabled[quarkus.micrometer.export.newrelic.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_NEWRELIC_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.enabled]]`link:#quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.enabled[quarkus.micrometer.export.newrelic.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-enabled]]`link:#quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-enabled[quarkus.micrometer.export.newrelic.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.default-registry]]`link:#quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic.default-registry[quarkus.micrometer.export.newrelic.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-default-registry]]`link:#quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-default-registry[quarkus.micrometer.export.newrelic.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic-newrelic]]`link:#quarkus-micrometer-export-newrelic_quarkus.micrometer.export.newrelic-newrelic[quarkus.micrometer.export.newrelic]`
+a| [[quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-newrelic]]`link:#quarkus-micrometer-export-newrelic_quarkus-micrometer-export-newrelic-newrelic[quarkus.micrometer.export.newrelic]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-otlp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-otlp.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-otlp_configuration]]link:#quarkus-micrometer-expor
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.get-enabled]]`link:#quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.get-enabled[quarkus.micrometer.export.otlp.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_OTLP_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_OTLP_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.enabled]]`link:#quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.enabled[quarkus.micrometer.export.otlp.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-enabled]]`link:#quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-enabled[quarkus.micrometer.export.otlp.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.default-registry]]`link:#quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp.default-registry[quarkus.micrometer.export.otlp.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-default-registry]]`link:#quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-default-registry[quarkus.micrometer.export.otlp.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp-otlp]]`link:#quarkus-micrometer-export-otlp_quarkus.micrometer.export.otlp-otlp[quarkus.micrometer.export.otlp]`
+a| [[quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-otlp]]`link:#quarkus-micrometer-export-otlp_quarkus-micrometer-export-otlp-otlp[quarkus.micrometer.export.otlp]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-signalfx.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-signalfx.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-signalfx_configuration]]link:#quarkus-micrometer-e
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.get-enabled]]`link:#quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.get-enabled[quarkus.micrometer.export.signalfx.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_SIGNALFX_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_SIGNALFX_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.enabled]]`link:#quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.enabled[quarkus.micrometer.export.signalfx.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-enabled]]`link:#quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-enabled[quarkus.micrometer.export.signalfx.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.default-registry]]`link:#quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx.default-registry[quarkus.micrometer.export.signalfx.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-default-registry]]`link:#quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-default-registry[quarkus.micrometer.export.signalfx.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx-signalfx]]`link:#quarkus-micrometer-export-signalfx_quarkus.micrometer.export.signalfx-signalfx[quarkus.micrometer.export.signalfx]`
+a| [[quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-signalfx]]`link:#quarkus-micrometer-export-signalfx_quarkus-micrometer-export-signalfx-signalfx[quarkus.micrometer.export.signalfx]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-stackdriver.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-stackdriver.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-stackdriver_configuration]]link:#quarkus-micromete
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.get-enabled]]`link:#quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.get-enabled[quarkus.micrometer.export.stackdriver.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_STACKDRIVER_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STACKDRIVER_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.enabled]]`link:#quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.enabled[quarkus.micrometer.export.stackdriver.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-enabled]]`link:#quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-enabled[quarkus.micrometer.export.stackdriver.enabled]`
 
 
 [.description]
@@ -56,7 +41,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.default-registry]]`link:#quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver.default-registry[quarkus.micrometer.export.stackdriver.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-default-registry]]`link:#quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-default-registry[quarkus.micrometer.export.stackdriver.default-registry]`
 
 
 [.description]
@@ -75,7 +60,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver-stackdriver]]`link:#quarkus-micrometer-export-stackdriver_quarkus.micrometer.export.stackdriver-stackdriver[quarkus.micrometer.export.stackdriver]`
+a| [[quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-stackdriver]]`link:#quarkus-micrometer-export-stackdriver_quarkus-micrometer-export-stackdriver-stackdriver[quarkus.micrometer.export.stackdriver]`
 
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-statsd.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-micrometer-export-statsd.adoc
@@ -10,22 +10,7 @@ h|[[quarkus-micrometer-export-statsd_configuration]]link:#quarkus-micrometer-exp
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.get-enabled]]`link:#quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.get-enabled[quarkus.micrometer.export.statsd.get-enabled]`
-
-
-[.description]
---
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MICROMETER_EXPORT_STATSD_GET_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MICROMETER_EXPORT_STATSD_GET_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.enabled]]`link:#quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.enabled[quarkus.micrometer.export.statsd.enabled]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-enabled]]`link:#quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-enabled[quarkus.micrometer.export.statsd.enabled]`
 
 
 [.description]
@@ -44,7 +29,7 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.default-registry]]`link:#quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd.default-registry[quarkus.micrometer.export.statsd.default-registry]`
+a|icon:lock[title=Fixed at build time] [[quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-default-registry]]`link:#quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-default-registry[quarkus.micrometer.export.statsd.default-registry]`
 
 
 [.description]
@@ -63,7 +48,7 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-a| [[quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd-statsd]]`link:#quarkus-micrometer-export-statsd_quarkus.micrometer.export.statsd-statsd[quarkus.micrometer.export.statsd]`
+a| [[quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-statsd]]`link:#quarkus-micrometer-export-statsd_quarkus-micrometer-export-statsd-statsd[quarkus.micrometer.export.statsd]`
 
 
 [.description]

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.6.7</quarkus.version>
+        <quarkus.version>3.7.1</quarkus.version>
 
         <skipTests>false</skipTests>
 


### PR DESCRIPTION
With Quarkus 3.7, the minimum Java version
has been bumped to 17, so we now
need to use that version in CI as well

Replaces https://github.com/quarkiverse/quarkus-micrometer-registry/pull/389