### PR TITLE
Add legacy Prometheus SimpleClient registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository hosts extensions that support additional Micrometer registry imp
 * SignalFx
 * Stackdriver
 * StatsD
+* Prometheus client v0.x (legacy)
 
 See the [Micrometer documentation](https://micrometer.io/) for details about Micrometer itself. Using Micrometer with Quarkus is explained in the [Quarkus Micrometer Guide](https://quarkus.io/guides/micrometer). [Quarkus Micrometer Extension documentation](https://quarkiverse.github.io/quarkiverse-docs/quarkus-micrometer-registry/dev/index.html) is generated from this project, and specifically covers how to configure Quarkus micrometer registry extensions.
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.22.1
+:quarkus-version: 3.22.3
 :quarkus-micrometer-registry-version: 3.3.1
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.21.1
+:quarkus-version: 3.22.1
 :quarkus-micrometer-registry-version: 3.3.1
 

--- a/docs/modules/ROOT/pages/micrometer-registry-prometheus-simpleclient.adoc
+++ b/docs/modules/ROOT/pages/micrometer-registry-prometheus-simpleclient.adoc
@@ -1,0 +1,12 @@
+= Micrometer Prometheus client v0.x (simpleclient)
+
+This is a legacy client and must not be used together with the new `io.quarkus:quarkus-micrometer-registry-prometheus` dependency.
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.quarkiverse.micrometer.registry</groupId>
+    <artifactId>quarkus-micrometer-registry-prometheus-simpleclient</artifactId>
+</dependency>
+----
+

--- a/integration-tests/micrometer-prometheus-simpleclient/pom.xml
+++ b/integration-tests/micrometer-prometheus-simpleclient/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.micrometer.registry</groupId>
+        <artifactId>quarkus-micrometer-registry-it-parent</artifactId>
+        <version>399-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-integration-test-micrometer-prometheus-simpleclient</artifactId>
+    <name>Quarkus - Integration Tests - Micrometer Prometheus SimpleClient </name>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-simpleclient</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Hibernate -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+
+        <!-- JAX-RS -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <!-- Verify that the client can co-exist with the server -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+
+        <!-- Verify extensions co-exist -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
+
+        <!-- Security -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.micrometer.registry</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-simpleclient-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/DummyTag.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/DummyTag.java
@@ -1,0 +1,15 @@
+package io.quarkus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+
+@Singleton
+public class DummyTag implements HttpServerMetricsTagsContributor {
+
+    @Override
+    public Tags contribute(Context context) {
+        return Tags.of("dummy", "value");
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/ExporterResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/ExporterResource.java
@@ -1,0 +1,43 @@
+package io.quarkus;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+
+@Path("/server-requests")
+@ApplicationScoped
+public class ExporterResource {
+    @Inject
+    MeterRegistry registry;
+
+    @Path("/count")
+    @Produces(MediaType.APPLICATION_JSON)
+    @GET
+    public Integer countServerRequests(@QueryParam("method") String method,
+            @QueryParam("outcome") String outcome,
+            @QueryParam("status") String status,
+            @QueryParam("uri") String uri) {
+        final Search search = registry
+                .find("http.server.requests");
+        if (method != null) {
+            search.tag("method", method);
+        }
+        if (outcome != null) {
+            search.tag("outcome", outcome);
+        }
+        if (status != null) {
+            search.tag("status", status);
+        }
+        if (uri != null) {
+            search.tag("uri", uri);
+        }
+        return search.timers().size();
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/HeaderTag.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/HeaderTag.java
@@ -1,0 +1,20 @@
+package io.quarkus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+
+@Singleton
+public class HeaderTag implements HttpServerMetricsTagsContributor {
+
+    @Override
+    public Tags contribute(Context context) {
+        String headerValue = context.request().getHeader("Foo");
+        String value = "UNSET";
+        if ((headerValue != null) && !headerValue.isEmpty()) {
+            value = headerValue;
+        }
+        return Tags.of("foo", value);
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -1,0 +1,20 @@
+package io.quarkus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.Tags;
+import io.quarkus.micrometer.runtime.HttpServerMetricsTagsContributor;
+
+@Singleton
+public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
+
+    @Override
+    public Tags contribute(Context context) {
+        var headerValue = context.response().headers().get("foo-response");
+        String value = "UNSET";
+        if ((headerValue != null) && !headerValue.isEmpty()) {
+            value = headerValue;
+        }
+        return Tags.of("foo-response", value);
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/Util.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/Util.java
@@ -1,0 +1,45 @@
+package io.quarkus;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class Util {
+    private Util() {
+    }
+
+    static String stackToString(Throwable t) {
+        StringBuilder sb = new StringBuilder().append("\n");
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        sb.append(t.getClass()).append(": ").append(t.getMessage()).append("\n");
+        Arrays.asList(t.getStackTrace()).forEach(x -> sb.append("\t").append(x.toString()).append("\n"));
+        return sb.toString();
+    }
+
+    public static String foundServerRequests(MeterRegistry registry, String message) {
+        return message + "\nFound:\n" + Util.listMeters(registry, "http.server.requests");
+    }
+
+    public static String foundClientRequests(MeterRegistry registry, String message) {
+        return message + "\nFound:\n" + Util.listMeters(registry, "http.client.requests");
+    }
+
+    public static String listMeters(MeterRegistry registry, String meterName) {
+        return registry.find(meterName).meters().stream()
+                .map(x -> {
+                    return x.getId().toString();
+                })
+                .collect(Collectors.joining("\n"));
+    }
+
+    public static String listMeters(MeterRegistry registry, String meterName, final String tag) {
+        return registry.find(meterName).meters().stream()
+                .map(x -> {
+                    return x.getId().getTag(tag);
+                })
+                .collect(Collectors.joining(","));
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/doc/micrometer/ExampleResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/doc/micrometer/ExampleResource.java
@@ -1,0 +1,133 @@
+/*-
+// tag::example[]
+
+package org.acme.micrometer;
+
+// tag::ignore[]
+*/
+// Source: integration-tests/micrometer-prometheus/src/main/java/io/quarkus/doc/micrometer/ExampleResource.java
+package io.quarkus.doc.micrometer;
+
+// end::ignore[]
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+
+@Path("/example")
+@Produces("text/plain")
+public class ExampleResource {
+    // tag::gauge[]
+    private final LinkedList<Long> list = new LinkedList<>(); // <1>
+
+    // end::gauge[]
+    // tag::registry[]
+    private final MeterRegistry registry;
+
+    // tag::ctor[]
+    ExampleResource(MeterRegistry registry) {
+        this.registry = registry;
+        // tag::gauge[]
+        registry.gaugeCollectionSize("example.list.size", Tags.empty(), list); // <2>
+        // end::gauge[]
+    }
+    // end::ctor[]
+    // end::registry[]
+    // tag::gauge[]
+
+    @GET
+    @Path("gauge/{number}")
+    public Long checkListSize(@PathParam("number") long number) { // <3>
+        if (number == 2 || number % 2 == 0) {
+            // add even numbers to the list
+            list.add(number);
+        } else {
+            // remove items from the list for odd numbers
+            try {
+                number = list.removeFirst();
+            } catch (NoSuchElementException nse) {
+                number = 0;
+            }
+        }
+        return number;
+    }
+    // end::gauge[]
+
+    // tag::primeMethod[]
+    @GET
+    @Path("prime/{number}")
+    public String checkIfPrime(@PathParam("number") long number) {
+        if (number < 1) {
+            // tag::counted[]
+            registry.counter("example.prime.number", "type", "not-natural") // <1>
+                    .increment(); // <2>
+            // end::counted[]
+            return "Only natural numbers can be prime numbers.";
+        }
+        if (number == 1) {
+            // tag::counted[]
+            registry.counter("example.prime.number", "type", "one") // <1>
+                    .increment(); // <2>
+            // end::counted[]
+            return number + " is not prime.";
+        }
+        if (number == 2 || number % 2 == 0) {
+            // tag::counted[]
+            registry.counter("example.prime.number", "type", "even") // <1>
+                    .increment(); // <2>
+            // end::counted[]
+            return number + " is not prime.";
+        }
+        // tag::timed[]
+        if (timedTestPrimeNumber(number)) { // <3>
+            // end::timed[]
+            // tag::ignore[]
+            registry.counter("example.prime.number", "type", "prime") // <1>
+                    .increment();
+            return number + " is prime.";
+        } else
+        // end::ignore[]
+        // tag::default[]
+        if (testPrimeNumber(number)) {
+            // end::default[]
+            // tag::counted[]
+            registry.counter("example.prime.number", "type", "prime") // <1>
+                    .increment(); // <2>
+            // end::counted[]
+            return number + " is prime.";
+        } else {
+            // tag::counted[]
+            registry.counter("example.prime.number", "type", "not-prime") // <1>
+                    .increment(); // <2>
+            // end::counted[]
+            return number + " is not prime.";
+        }
+    }
+    // end::primeMethod[]
+    // tag::timed[]
+
+    protected boolean timedTestPrimeNumber(long number) {
+        Timer.Sample sample = Timer.start(registry); // <4>
+        boolean result = testPrimeNumber(number); // <5>
+        sample.stop(registry.timer("example.prime.number.test", "prime", result + "")); // <6>
+        return result;
+    }
+    // end::timed[]
+
+    protected boolean testPrimeNumber(long number) {
+        for (int i = 3; i < Math.floor(Math.sqrt(number)) + 1; i = i + 2) {
+            if (number % i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+// end::example[]

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/AnnotatedResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/AnnotatedResource.java
@@ -1,0 +1,142 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.logging.Logger;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.aop.MeterTag;
+
+@Path("/all-the-things")
+public class AnnotatedResource {
+    private static final Logger log = Logger.getLogger(AnnotatedResource.class);
+
+    @GET
+    public String allTheThings() {
+        // Counted
+        onlyCountFailures();
+        countAllInvocations(false);
+        emptyMetricName(false);
+        wrap(x -> countAllInvocations(true));
+        wrap(x -> emptyMetricName(true));
+
+        join(x -> onlyCountAsyncFailures());
+        join(x -> countAllAsyncInvocations(false));
+        join(x -> emptyAsyncMetricName(false));
+        join(x -> countAllAsyncInvocations(true));
+        join(x -> emptyAsyncMetricName(true));
+
+        //Timed
+        call(false);
+        longCall(false);
+        wrap(x -> call(true));
+        wrap(x -> longCall(true));
+
+        join(x -> asyncCall(false));
+        join(x -> longAsyncCall(false));
+        join(x -> asyncCall(true));
+        join(x -> longAsyncCall(true));
+
+        return "OK";
+    }
+
+    void wrap(Function<Boolean, Object> function) {
+        try {
+            function.apply(true);
+        } catch (NullPointerException e) {
+            if (!e.getMessage().equals("Failed on purpose")) {
+                log.error("Unexpected exception in test", e);
+                throw e;
+            }
+        }
+    }
+
+    void join(Function<Boolean, CompletableFuture<?>> function) {
+        try {
+            function.apply(true).join();
+        } catch (CompletionException e) {
+            if (!e.getCause().getMessage().equals("Failed on purpose")) {
+                log.error("unexpected exception in test", e);
+                throw e;
+            }
+        }
+    }
+
+    @Counted(value = "metric.none", recordFailuresOnly = true)
+    public Object onlyCountFailures() {
+        return new Response(false).get();
+    }
+
+    @Counted(value = "metric.all", extraTags = { "extra", "tag" })
+    public Object countAllInvocations(@MeterTag boolean fail) {
+        return new Response(fail).get();
+    }
+
+    @Counted(description = "nice description")
+    public Object emptyMetricName(@MeterTag(resolver = PrefixingValueResolver.class) boolean fail) {
+        return new Response(fail).get();
+    }
+
+    @Counted(value = "async.none", recordFailuresOnly = true)
+    public CompletableFuture<?> onlyCountAsyncFailures() {
+        return CompletableFuture.supplyAsync(new Response(false));
+    }
+
+    @Counted(value = "async.all", extraTags = { "extra", "tag" })
+    public CompletableFuture<?> countAllAsyncInvocations(@MeterTag(key = "do_fail_call") boolean fail) {
+        return CompletableFuture.supplyAsync(new Response(fail));
+    }
+
+    @Counted
+    public CompletableFuture<?> emptyAsyncMetricName(@MeterTag(expression = "expression") boolean fail) {
+        return CompletableFuture.supplyAsync(new Response(fail));
+    }
+
+    @Timed(value = "call", extraTags = { "extra", "tag" })
+    public Object call(boolean fail) {
+        return new Response(fail).get();
+    }
+
+    @Timed(value = "longCall", extraTags = { "extra", "tag" }, longTask = true)
+    public Object longCall(boolean fail) {
+        return new Response(fail).get();
+    }
+
+    @Timed(value = "async.call", extraTags = { "extra", "tag" })
+    public CompletableFuture<?> asyncCall(boolean fail) {
+        return CompletableFuture.supplyAsync(new Response(fail));
+    }
+
+    @Timed(value = "async.longCall", extraTags = { "extra", "tag" }, longTask = true)
+    public CompletableFuture<?> longAsyncCall(boolean fail) {
+        return CompletableFuture.supplyAsync(new Response(fail));
+    }
+
+    static class Response implements Supplier<Object> {
+        boolean fail;
+
+        Response(boolean fail) {
+            this.fail = fail;
+        }
+
+        @Override
+        public Object get() {
+            try {
+                Thread.sleep(3);
+            } catch (InterruptedException e) {
+                // intentionally empty
+            }
+            if (fail) {
+                throw new NullPointerException("Failed on purpose");
+            }
+            return new Object();
+        }
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/AnswerToEverythingExpressionResolver.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/AnswerToEverythingExpressionResolver.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.common.annotation.ValueExpressionResolver;
+
+@Singleton
+public class AnswerToEverythingExpressionResolver implements ValueExpressionResolver {
+    @Override
+    public String resolve(String expression, Object parameter) {
+        // Answer to the Ultimate Question of Life, the Universe, and Everything.
+        return "42";
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/CustomConfiguration.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/CustomConfiguration.java
@@ -1,0 +1,127 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.Arrays;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.quarkus.micrometer.runtime.MeterFilterConstraint;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizer;
+import io.quarkus.micrometer.runtime.MeterRegistryCustomizerConstraint;
+
+@Singleton
+@Priority(Interceptor.Priority.APPLICATION - 100)
+public class CustomConfiguration {
+
+    @ConfigProperty(name = "deployment.env")
+    String deploymentEnv;
+
+    @Produces
+    @Singleton
+    @MeterFilterConstraint(applyTo = PrometheusMeterRegistry.class)
+    public MeterFilter configurePrometheusRegistries() {
+        return MeterFilter.commonTags(Arrays.asList(
+                Tag.of("registry", "prometheus")));
+    }
+
+    @Produces
+    @Singleton
+    @MeterFilterConstraint(applyTo = PrometheusMeterRegistry.class)
+    public MeterFilter configurePrometheusRegistries2() {
+        return MeterFilter.commonTags(Arrays.asList(
+                Tag.of("registry2", "prometheus")));
+    }
+
+    @Produces
+    @Singleton
+    @MeterFilterConstraint(applyTo = CustomConfiguration.class)
+    public MeterFilter configureNonexistantRegistries() {
+        return MeterFilter.commonTags(Arrays.asList(
+                Tag.of("tag", "class-should-not-match")));
+    }
+
+    @Produces
+    @Singleton
+    public MeterFilter configureAllRegistries() {
+        return MeterFilter.commonTags(Arrays.asList(
+                Tag.of("env", deploymentEnv)));
+    }
+
+    @Produces
+    @Singleton
+    @MeterRegistryCustomizerConstraint(applyTo = PrometheusMeterRegistry.class)
+    public MeterRegistryCustomizer customizePrometheusRegistries() {
+        return new MeterRegistryCustomizer() {
+            @Override
+            public void customize(MeterRegistry registry) {
+                registry.config().meterFilter(MeterFilter.ignoreTags("registry2"));
+            }
+        };
+    }
+
+    @Produces
+    @Singleton
+    @MeterRegistryCustomizerConstraint(applyTo = CustomConfiguration.class)
+    public MeterRegistryCustomizer customizeNonexistantRegistries() {
+        return new MeterRegistryCustomizer() {
+            @Override
+            public void customize(MeterRegistry registry) {
+                registry.config().meterFilter(MeterFilter.ignoreTags("env"));
+            }
+        };
+    }
+
+    @Produces
+    @Singleton
+    public MeterRegistryCustomizer customizeAllRegistries() {
+        return new MeterRegistryCustomizer() {
+            @Override
+            public void customize(MeterRegistry registry) {
+                registry.config().meterFilter(MeterFilter.commonTags(Arrays.asList(
+                        Tag.of("env2", deploymentEnv))));
+            }
+        };
+    }
+
+    /**
+     * Produce a custom prometheus configuration that is isolated/separate from
+     * the application (and won't be connected to the Quarkus configured application
+     * endpoint).
+     */
+    @Produces
+    @Singleton
+    public PrometheusMeterRegistry registry(CollectorRegistry collectorRegistry, Clock clock) {
+        return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, collectorRegistry, clock);
+    }
+
+    /** Enable histogram buckets for a specific timer */
+    @Produces
+    @Singleton
+    public MeterFilter enableHistogram() {
+        return new MeterFilter() {
+            public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                if (id.getName().equals("prime.number.test")) {
+                    return DistributionStatisticConfig.builder()
+                            .percentiles(0.5, 0.95) // median and 95th percentile
+                            .percentilesHistogram(true) // histogram buckets (for use with prometheus histogram_quantile)
+                            .build()
+                            .merge(config);
+                }
+                return config;
+            }
+        };
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/Fruit.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/Fruit.java
@@ -1,0 +1,17 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.persistence.Entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity
+public class Fruit extends PanacheEntity {
+    public String name;
+
+    public Fruit(String name) {
+        this.name = name;
+    }
+
+    public Fruit() {
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/FruitResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/FruitResource.java
@@ -1,0 +1,40 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.jboss.resteasy.reactive.RestResponse;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.smallrye.common.annotation.Blocking;
+
+@Path("/fruit")
+@Blocking
+public class FruitResource {
+
+    @GET
+    @Path("create")
+    @Transactional
+    public void trigger() {
+        Fruit apple = new Fruit("apple");
+        Fruit pear = new Fruit("pear");
+        Fruit banana = new Fruit("banana");
+
+        Fruit.persist(apple, pear, banana);
+    }
+
+    @GET
+    @Path("all")
+    public RestResponse<Object> retrieveAll() {
+        PanacheQuery<Fruit> query = Fruit.find(
+                "select name from Fruit");
+        List<Fruit> all = query.list();
+
+        return RestResponse.ResponseBuilder.noContent()
+                .header("foo-response", "value")
+                .build();
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/message")
+public class MessageResource implements MessageResourceApi {
+
+    private final MeterRegistry registry;
+
+    public MessageResource(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @GET
+    public String message() {
+        return registry.getClass().getName();
+    }
+
+    @GET
+    @Path("fail")
+    public String fail() {
+        throw new NullPointerException("Failed on purpose");
+    }
+
+    @GET
+    @Path("item/{id}")
+    public String item(@PathParam("id") String id) {
+        return "return message with id " + id;
+    }
+
+    @Override
+    public String match(String id, String sub) {
+        return "return message with id " + id + ", and sub " + sub;
+    }
+
+    @Override
+    public String optional(String text) {
+        return "return message with text " + text;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResourceApi.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResourceApi.java
@@ -1,0 +1,14 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+// Splitting JAX-RS annotations to interfaces tests the behaviour of
+// io.quarkus.resteasy.deployment.RestPathAnnotationProcessor
+public interface MessageResourceApi extends MessageResourceNestedApi {
+
+    @GET
+    @Path("match/{id}/{sub}")
+    String match(@PathParam("id") String id, @PathParam("sub") String sub);
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResourceNestedApi.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/MessageResourceNestedApi.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+// Testing deep lookup of Path-annotation
+public interface MessageResourceNestedApi {
+
+    @GET
+    @Path("match/{text}")
+    String optional(@PathParam("text") String text);
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PathTemplateResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PathTemplateResource.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("template/path/{value}")
+public class PathTemplateResource {
+    @GET
+    public String get(@PathParam("value") String value) {
+        return "Received: " + value;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PingPongResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PingPongResource.java
@@ -1,0 +1,102 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.resteasy.reactive.RestPath;
+
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+@Path("/client")
+public class PingPongResource {
+    @RegisterRestClient(configKey = "pingpong")
+    public interface PingPongRestClient {
+
+        @Path("/client/pong/{message}")
+        @GET
+        String pingpong(@PathParam("message") String message);
+
+        @GET
+        @Path("/client/pong/{message}")
+        Uni<String> asyncPingpong(@PathParam("message") String message);
+
+        @GET
+        @Path("/client/status/{statusCode}")
+        public void call(@RestPath int statusCode);
+
+        @GET
+        @Path("/client/status/{statusCode}/{sleep}")
+        public void call(@RestPath int statusCode, @RestPath int sleep);
+    }
+
+    @Inject
+    @RestClient
+    PingPongRestClient pingRestClient;
+
+    @GET
+    @Path("pong/{message}")
+    public String pong(@PathParam("message") String message) {
+        return message;
+    }
+
+    @GET
+    @Blocking
+    @Path("ping/{message}")
+    public String ping(@PathParam("message") String message) {
+        return pingRestClient.pingpong(message);
+    }
+
+    @GET
+    @Path("async-ping/{message}")
+    public Uni<String> asyncPing(@PathParam("message") String message) {
+        return pingRestClient.asyncPingpong(message);
+    }
+
+    @GET
+    @Path("status")
+    public String clientStatus() {
+        String result = "";
+        pingRestClient.call(200);
+        result += "ok";
+        try {
+            pingRestClient.call(400);
+        } catch (Exception ignored) {
+            result += "400";
+        }
+        try {
+            pingRestClient.call(500);
+        } catch (Exception ignored) {
+            result += "500";
+        }
+        try {
+            pingRestClient.call(200, 5000);
+        } catch (Exception ignored) {
+            result += "timeout";
+        }
+        return result;
+    }
+
+    @GET
+    @Path("status/{statusCode}")
+    public Response testStatus(@RestPath int statusCode) {
+        return Response.status(statusCode).build();
+    }
+
+    @GET
+    @Path("status/{statusCode}/{sleep}")
+    public Response testStatusSleep(@RestPath int statusCode, @RestPath int sleep) {
+        try {
+            Thread.sleep(sleep);
+        } catch (InterruptedException ignored) {
+        }
+        return Response.status(statusCode).build();
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PrefixingValueResolver.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PrefixingValueResolver.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.inject.Singleton;
+
+import io.micrometer.common.annotation.ValueResolver;
+
+@Singleton
+public class PrefixingValueResolver implements ValueResolver {
+    @Override
+    public String resolve(Object parameter) {
+        return "prefix " + parameter;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PrimeNumberResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/PrimeNumberResource.java
@@ -1,0 +1,66 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.function.Supplier;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/prime")
+public class PrimeNumberResource {
+
+    private final LongAccumulator highestPrime = new LongAccumulator(Long::max, 0);
+    private final MeterRegistry registry;
+
+    PrimeNumberResource(MeterRegistry registry) {
+        this.registry = registry;
+
+        // Create a gauge that uses the highestPrimeNumberSoFar method
+        // to obtain the highest observed prime number
+        registry.gauge("prime.number.max", this,
+                PrimeNumberResource::highestObservedPrimeNumber);
+    }
+
+    @GET
+    @Path("/{number}")
+    @Produces("text/plain")
+    public String checkIfPrime(@PathParam("number") long number) {
+        if (number < 1) {
+            return "Only natural numbers can be prime numbers.";
+        }
+        if (number == 1) {
+            return "1 is not prime.";
+        }
+        if (number == 2) {
+            return "2 is prime.";
+        }
+        if (number % 2 == 0) {
+            return number + " is not prime, it is divisible by 2.";
+        }
+
+        Supplier<String> supplier = () -> {
+            for (int i = 3; i < Math.floor(Math.sqrt(number)) + 1; i = i + 2) {
+                if (number % i == 0) {
+                    return number + " is not prime, is divisible by " + i + ".";
+                }
+            }
+            highestPrime.accumulate(number);
+            return number + " is prime.";
+        };
+
+        return registry.timer("prime.number.test").wrap(supplier).get();
+    }
+
+    /**
+     * This method is called by the registered {@code highest.prime.number} gauge.
+     *
+     * @return the highest observed prime value
+     */
+    long highestObservedPrimeNumber() {
+        return highestPrime.get();
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/RootResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/RootResource.java
@@ -1,0 +1,13 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/root")
+public class RootResource {
+
+    @Path("{rootParam}/sub")
+    public SubResource subResource(@PathParam("rootParam") String value) {
+        return new SubResource(value);
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/SecuredResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/SecuredResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+@Path("/secured")
+public class SecuredResource {
+
+    @GET
+    @Path("item/{id}")
+    public String item(@PathParam("id") String id) {
+        return "return message with id " + id;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/SubResource.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/java/io/quarkus/it/micrometer/prometheus/SubResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+public class SubResource {
+
+    private final String value;
+
+    public SubResource(String value) {
+        this.value = value;
+    }
+
+    @GET
+    @Path("/{subParam}")
+    public String get(@PathParam("subParam") String subParam) {
+        return value + ":" + subParam;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/main/resources/application.properties
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/main/resources/application.properties
@@ -1,0 +1,41 @@
+#quarkus.log.min-level=DEBUG
+#quarkus.log.category."io.quarkus.micrometer".level=DEBUG
+quarkus.log.category."io.quarkus.bootstrap".level=INFO
+quarkus.log.category."io.quarkus.netty".level=INFO
+quarkus.log.category."io.quarkus.resteasy.runtime".level=INFO
+
+quarkus.log.category."io.netty".level=INFO
+quarkus.log.category."org.apache".level=INFO
+
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.statistics=true
+quarkus.hibernate-orm.metrics.enabled=true
+
+quarkus.datasource.db-kind=h2
+quarkus.datasource.devservices.enabled=true
+
+# This is the old property, should still be usable
+quarkus.micrometer.binder.vertx.ignore-patterns=/fruit/create
+
+# Verify match pattern behavior
+quarkus.micrometer.binder.http-server.match-patterns=/message/match/\\\\d+/[0-9]+=/message/match/{id}/{sub},\
+/message/match/.*=/message/match/{other}
+
+quarkus.rest-client.pingpong.url=${test.url}
+quarkus.rest-client.read-timeout=1000
+
+deployment.env=test
+
+# Disable Kubernetes dev services as not supported on Windows
+quarkus.kubernetes-client.devservices.enabled=false
+
+
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.scott=reader
+quarkus.security.users.embedded.users.stuart=writer
+quarkus.security.users.embedded.roles.scott=READER
+quarkus.security.users.embedded.roles.stuart=READER,WRITER
+quarkus.http.auth.permission.secured.policy=authenticated
+quarkus.http.auth.permission.secured.paths=/secured/*
+

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestIT.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ClientRequestIT extends ClientRequestTest {
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestTest.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ClientRequestTest.java
@@ -1,0 +1,117 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ClientRequestTest {
+
+    @Test
+    void testClientRequests() {
+        when().get("/client/ping/one").then().statusCode(200)
+                .body(containsString("one"));
+        when().get("/client/ping/two").then().statusCode(200)
+                .body(containsString("two"));
+        when().get("/client/async-ping/one").then().statusCode(200)
+                .body(containsString("one"));
+        when().get("/client/async-ping/two").then().statusCode(200)
+                .body(containsString("two"));
+        when().get("/client/status").then().statusCode(200)
+                .body(containsString("ok400500timeout"));
+
+        await().atMost(5, SECONDS).untilAsserted(() -> assertThat(
+                get("/server-requests/count").body().as(Integer.class),
+                greaterThan(7)));
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/pong/{message}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/pong/{message}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/ping/{message}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/ping/{message}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/pong/{message}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/pong/{message}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/async-ping/{message}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/async-ping/{message}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/status")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/status");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SUCCESS")
+                        .queryParam("status", "200")
+                        .queryParam("uri", "/client/status/{statusCode}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=200, uri=/client/status/{statusCode}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "CLIENT_ERROR")
+                        .queryParam("status", "400")
+                        .queryParam("uri", "/client/status/{statusCode}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=400, uri=/client/status/{statusCode}");
+
+        assertEquals(1,
+                given()
+                        .queryParam("method", "GET")
+                        .queryParam("outcome", "SERVER_ERROR")
+                        .queryParam("status", "500")
+                        .queryParam("uri", "/client/status/{statusCode}")
+                        .when().get("/server-requests/count")
+                        .body().as(Integer.class),
+                "Expected: http.server.requests, method=GET, status=500, uri=/client/status/{statusCode}");
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesIT.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class ExampleResourcesIT extends ExampleResourcesTest {
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExampleResourcesTest.java
@@ -1,0 +1,67 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/** See Micrometer Guide */
+@QuarkusTest
+public class ExampleResourcesTest {
+
+    @Test
+    void testGaugeExample() {
+        when().get("/example/gauge/1").then().statusCode(200);
+        when().get("/example/gauge/2").then().statusCode(200);
+        when().get("/example/gauge/4").then().statusCode(200);
+        when().get("/q/metrics").then().statusCode(200)
+                .body(containsString(
+                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"));
+        when().get("/example/gauge/6").then().statusCode(200);
+        when().get("/example/gauge/5").then().statusCode(200);
+        when().get("/example/gauge/7").then().statusCode(200);
+        when().get("/q/metrics").then().statusCode(200)
+                .body(containsString(
+                        "example_list_size{env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"));
+    }
+
+    @Test
+    void testCounterExample() {
+        when().get("/example/prime/-1").then().statusCode(200);
+        when().get("/example/prime/0").then().statusCode(200);
+        when().get("/example/prime/1").then().statusCode(200);
+        when().get("/example/prime/2").then().statusCode(200);
+        when().get("/example/prime/3").then().statusCode(200);
+        when().get("/example/prime/15").then().statusCode(200);
+
+        when().get("/q/metrics").then().statusCode(200)
+                .body(containsString(
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"prime\"}"))
+                .body(containsString(
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-prime\"}"))
+                .body(containsString(
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"one\"}"))
+                .body(containsString(
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"even\"}"))
+                .body(containsString(
+                        "example_prime_number_total{env=\"test\",env2=\"test\",registry=\"prometheus\",type=\"not-natural\"}"));
+    }
+
+    @Test
+    void testTimerExample() {
+        when().get("/example/prime/257").then().statusCode(200);
+        when().get("/q/metrics").then().statusCode(200)
+                .body(containsString(
+                        "example_prime_number_test_seconds_sum{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
+                .body(containsString(
+                        "example_prime_number_test_seconds_max{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"}"))
+                .body(containsString(
+                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 1.0"));
+        when().get("/example/prime/7919").then().statusCode(200);
+        when().get("/q/metrics").then().statusCode(200)
+                .body(containsString(
+                        "example_prime_number_test_seconds_count{env=\"test\",env2=\"test\",prime=\"true\",registry=\"prometheus\"} 2.0"));
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarOffTest.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarOffTest.java
@@ -1,0 +1,34 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.when;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * See Micrometer Guide
+ */
+@QuarkusTest
+@TestProfile(OtelOffProfile.class)
+public class ExemplarOffTest {
+
+    @Test
+    void testExemplar() {
+        when().get("/example/prime/257").then().statusCode(200);
+        when().get("/example/prime/7919").then().statusCode(200);
+
+        String metricMatch = "http_server_requests_seconds_count{dummy=\"value\",env=\"test\"," +
+                "env2=\"test\",foo=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\"," +
+                "registry=\"prometheus\",status=\"200\",uri=\"/example/prime/{number}\"} 2.0 # {span_id=\"";
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            assertFalse(get("/q/metrics").then().extract().asString().contains(metricMatch));
+        });
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarTest.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/ExemplarTest.java
@@ -1,0 +1,35 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.when;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * See Micrometer Guide
+ */
+@QuarkusTest
+@TestProfile(OtelOnProfile.class)
+public class ExemplarTest {
+
+    @Test
+    void testExemplar() {
+        when().get("/example/prime/257").then().statusCode(200);
+        when().get("/example/prime/7919").then().statusCode(200);
+
+        String metricMatch = "http_server_requests_seconds_count{dummy=\"value\",env=\"test\"," +
+                "env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\"," +
+                "registry=\"prometheus\",status=\"200\",uri=\"/example/prime/{number}\"} 2.0 # {span_id=\"";
+
+        await().atMost(5, SECONDS).untilAsserted(() -> {
+            String body = get("/q/metrics").then().extract().asString();
+            assertTrue(body.contains(metricMatch), body);
+        });
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/OtelOffProfile.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/OtelOffProfile.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class OtelOffProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<>(Map.of(
+                "quarkus.otel.enabled", "false"));
+        return config;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/OtelOnProfile.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/OtelOnProfile.java
@@ -1,0 +1,16 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class OtelOnProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<>(Map.of(
+                "quarkus.otel.enabled", "true"));
+        return config;
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryIT.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class PrometheusMetricsRegistryIT extends PrometheusMetricsRegistryTest {
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/PrometheusMetricsRegistryTest.java
@@ -1,0 +1,299 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.prometheus.client.exporter.common.TextFormat;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+/**
+ * Test functioning prometheus endpoint.
+ * Use test execution order to ensure one http server request measurement
+ * is present when the endpoint is scraped.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PrometheusMetricsRegistryTest {
+
+    @Test
+    @Order(1)
+    void testRegistryInjection() {
+        when().get("/message").then().statusCode(200)
+                .body(containsString("io.micrometer.core.instrument.composite.CompositeMeterRegistry"));
+    }
+
+    @Test
+    @Order(2)
+    void testUnknownUrl() {
+        when().get("/message/notfound").then().statusCode(404);
+    }
+
+    @Test
+    @Order(3)
+    void testServerError() {
+        when().get("/message/fail").then().statusCode(500);
+    }
+
+    @Test
+    @Order(4)
+    void testPathParameter() {
+        given().header("foo", "bar").when().get("/message/item/123").then().statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void testMultipleParameters() {
+        when().get("/message/match/123/1").then().statusCode(200);
+
+        when().get("/message/match/1/123").then().statusCode(200);
+
+        when().get("/message/match/baloney").then().statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void testPanacheCalls() {
+        when().get("/fruit/create").then().statusCode(204);
+
+        when().get("/fruit/all").then().statusCode(204);
+    }
+
+    @Test
+    @Order(7)
+    void testPrimeEndpointCalls() {
+        when().get("/prime/7").then().statusCode(200)
+                .body(containsString("is prime"));
+    }
+
+    @Test
+    @Order(8)
+    void testAllTheThings() {
+        when().get("/all-the-things").then().statusCode(200)
+                .body(containsString("OK"));
+    }
+
+    @Test
+    @Order(9)
+    void testTemplatedPathOnClass() {
+        when().get("/template/path/anything").then().statusCode(200)
+                .body(containsString("Received: anything"));
+    }
+
+    @Test
+    @Order(10)
+    void testSecuredEndpoint() {
+        when().get("/secured/item/123").then().statusCode(401);
+        given().auth().preemptive().basic("foo", "bar").when().get("/secured/item/321").then().statusCode(401);
+        given().auth().preemptive().basic("scott", "reader").when().get("/secured/item/123").then().statusCode(200);
+        given().auth().preemptive().basic("stuart", "writer").when().get("/secured/item/321").then().statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void testTemplatedPathOnSubResource() {
+        when().get("/root/r1/sub/s2").then().statusCode(200)
+                .body(containsString("r1:s2"));
+    }
+
+    @Test
+    @Order(20)
+    void testPrometheusScrapeEndpointTextPlain() {
+        RestAssured.given().header("Accept", TextFormat.CONTENT_TYPE_004)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+
+                // Prometheus body has ALL THE THINGS in no particular order
+
+                .body(containsString("registry=\"prometheus\""))
+                .body(containsString("env=\"test\""))
+                .body(containsString("http_server_requests"))
+
+                .body(containsString("status=\"404\""))
+                .body(containsString("uri=\"NOT_FOUND\""))
+                .body(containsString("outcome=\"CLIENT_ERROR\""))
+
+                .body(containsString("status=\"500\""))
+                .body(containsString("uri=\"/message/fail\""))
+                .body(containsString("outcome=\"SERVER_ERROR\""))
+
+                .body(containsString("status=\"200\""))
+                .body(containsString("uri=\"/message\""))
+                .body(containsString("uri=\"/message/item/{id}\""))
+                .body(containsString("status=\"200\",uri=\"/message/item/{id}\""))
+                .body(containsString("uri=\"/secured/item/{id}\""))
+                .body(containsString("status=\"200\",uri=\"/secured/item/{id}\""))
+                .body(containsString("status=\"401\",uri=\"/secured/item/{id}\""))
+                .body(containsString("outcome=\"SUCCESS\""))
+                .body(containsString("dummy=\"value\""))
+                .body(containsString("foo=\"bar\""))
+                .body(containsString("foo_response=\"value\""))
+                .body(containsString("uri=\"/message/match/{id}/{sub}\""))
+                .body(containsString("uri=\"/message/match/{other}\""))
+
+                .body(containsString(
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+
+                .body(containsString(
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/root/{rootParam}/sub/{subParam}\""))
+
+                // Verify Hibernate Metrics
+                .body(containsString(
+                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 2.0"))
+                .body(containsString(
+                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 2.0"))
+                .body(containsString(
+                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",}"))
+                .body(containsString(
+                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 3.0"))
+                .body(containsString(
+                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\",} 1.0"))
+
+                // Annotated counters
+                .body(not(containsString("metric_none")))
+                .body(containsString(
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",fail=\"false\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                .body(containsString(
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",fail=\"true\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"prefix true\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"prefix false\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                .body(not(containsString("async_none")))
+                .body(containsString(
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"true\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                .body(containsString(
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"false\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\",} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\",} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\",} 1.0"))
+
+                // Annotated Timers
+                .body(containsString(
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\",} 1.0"))
+                .body(containsString(
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\",}"))
+                .body(containsString(
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
+                .body(containsString(
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\",} 1.0"))
+                .body(containsString(
+                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\",}"))
+                .body(containsString(
+                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\",} 0.0"))
+
+                // Configured median, 95th percentile and histogram buckets
+                .body(containsString(
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\",}"))
+                .body(containsString(
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\",}"))
+                .body(containsString(
+                        "prime_number_test_seconds_bucket{env=\"test\",env2=\"test\",registry=\"prometheus\",le=\"0.001\",}"))
+
+                // this was defined by a tag to a non-matching registry, and should not be found
+                .body(not(containsString("class-should-not-match")))
+
+                // should not find this ignored uri
+                .body(not(containsString("uri=\"/fruit/create\"")));
+    }
+
+    @Test
+    @Order(20)
+    void testPrometheusScrapeEndpointOpenMetrics() {
+        RestAssured.given().header("Accept", TextFormat.CONTENT_TYPE_OPENMETRICS_100)
+                .when().get("/q/metrics")
+                .then().statusCode(200)
+
+                // Prometheus body has ALL THE THINGS in no particular order
+
+                .body(containsString("registry=\"prometheus\""))
+                .body(containsString("env=\"test\""))
+                .body(containsString("http_server_requests"))
+
+                .body(containsString("status=\"404\""))
+                .body(containsString("uri=\"NOT_FOUND\""))
+                .body(containsString("outcome=\"CLIENT_ERROR\""))
+
+                .body(containsString("status=\"500\""))
+                .body(containsString("uri=\"/message/fail\""))
+                .body(containsString("outcome=\"SERVER_ERROR\""))
+
+                .body(containsString("status=\"200\""))
+                .body(containsString("uri=\"/message\""))
+                .body(containsString("uri=\"/message/item/{id}\""))
+                .body(containsString("outcome=\"SUCCESS\""))
+                .body(containsString("uri=\"/message/match/{id}/{sub}\""))
+                .body(containsString("uri=\"/message/match/{other}\""))
+
+                .body(containsString(
+                        "http_server_requests_seconds_count{dummy=\"value\",env=\"test\",env2=\"test\",foo=\"UNSET\",foo_response=\"UNSET\",method=\"GET\",outcome=\"SUCCESS\",registry=\"prometheus\",status=\"200\",uri=\"/template/path/{value}\""))
+
+                // Verify Hibernate Metrics
+                .body(containsString(
+                        "hibernate_sessions_open_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
+                .body(containsString(
+                        "hibernate_sessions_closed_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 2.0"))
+                .body(containsString(
+                        "hibernate_connections_obtained_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"}"))
+                .body(containsString(
+                        "hibernate_entities_inserts_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 3.0"))
+                .body(containsString(
+                        "hibernate_flushes_total{entityManagerFactory=\"<default>\",env=\"test\",env2=\"test\",registry=\"prometheus\"} 1.0"))
+
+                // Annotated counters
+                .body(not(containsString("metric_none")))
+                .body(containsString(
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",fail=\"false\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"success\"} 1.0 # {span_id="))
+                .body(containsString(
+                        "metric_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",fail=\"true\",method=\"countAllInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"prefix true\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0 # {span_id="))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"prefix false\",method=\"emptyMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                .body(not(containsString("async_none")))
+                .body(containsString(
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"true\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                .body(containsString(
+                        "async_all_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",do_fail_call=\"false\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"countAllAsyncInvocations\",registry=\"prometheus\",result=\"success\"} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"failure\"} 1.0"))
+                .body(containsString(
+                        "method_counted_total{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",fail=\"42\",method=\"emptyAsyncMetricName\",registry=\"prometheus\",result=\"success\"} 1.0"))
+
+                // Annotated Timers
+                .body(containsString(
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"call\",registry=\"prometheus\"} 1.0"))
+                .body(containsString(
+                        "call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"call\",registry=\"prometheus\"}"))
+                .body(containsString(
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"NullPointerException\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
+                .body(containsString(
+                        "async_call_seconds_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",exception=\"none\",extra=\"tag\",method=\"asyncCall\",registry=\"prometheus\"} 1.0"))
+                .body(containsString(
+                        "longCall_seconds_active_count{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longCall\",registry=\"prometheus\"}"))
+                .body(containsString(
+                        "async_longCall_seconds_duration_sum{class=\"io.quarkus.it.micrometer.prometheus.AnnotatedResource\",env=\"test\",env2=\"test\",extra=\"tag\",method=\"longAsyncCall\",registry=\"prometheus\"} 0.0"))
+
+                // Configured median, 95th percentile and histogram buckets
+                .body(containsString(
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.5\"}"))
+                .body(containsString(
+                        "prime_number_test_seconds{env=\"test\",env2=\"test\",registry=\"prometheus\",quantile=\"0.95\"}"))
+                .body(containsString(
+                        "prime_number_test_seconds_bucket{env=\"test\",env2=\"test\",registry=\"prometheus\",le=\"0.001\"}"))
+
+                // this was defined by a tag to a non-matching registry, and should not be found
+                .body(not(containsString("class-should-not-match")))
+
+                // should not find this ignored uri
+                .body(not(containsString("uri=\"/fruit/create\"")));
+    }
+}

--- a/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
+++ b/integration-tests/micrometer-prometheus-simpleclient/src/test/java/io/quarkus/it/micrometer/prometheus/TestResources.java
@@ -1,0 +1,8 @@
+package io.quarkus.it.micrometer.prometheus;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+
+@QuarkusTestResource(H2DatabaseTestResource.class)
+public class TestResources {
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -25,6 +25,7 @@
     <modules>
         <module>micrometer-jmx</module>
         <module>micrometer-native</module>
+        <module>micrometer-prometheus-simpleclient</module>
     </modules>
 
     <build>

--- a/micrometer-registry-prometheus-simpleclient/deployment/pom.xml
+++ b/micrometer-registry-prometheus-simpleclient/deployment/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.micrometer.registry</groupId>
+        <artifactId>quarkus-micrometer-registry-prometheus-simpleclient-parent</artifactId>
+        <version>399-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-micrometer-registry-prometheus-simpleclient-deployment</artifactId>
+    <description>Enable Prometheus support for Micrometer with the legacy v0.x client - Deployment</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.micrometer.registry</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus-simpleclient</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-deployment</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <quarkus.log.level>INFO</quarkus.log.level>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${quarkus.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/micrometer-registry-prometheus-simpleclient/deployment/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/deployment/PrometheusSimpleProcessor.java
+++ b/micrometer-registry-prometheus-simpleclient/deployment/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/deployment/PrometheusSimpleProcessor.java
@@ -1,0 +1,94 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.ConditionalRegistryProducer;
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.PrometheusSimpleConfig;
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.PrometheusSimpleMeterRegistryProvider;
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars.EmptyExemplarSamplerProvider;
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars.OpentelemetryExemplarSamplerProvider;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.micrometer.deployment.MicrometerRegistryProviderBuildItem;
+import io.quarkus.micrometer.deployment.export.PrometheusRegistryProcessor;
+import io.quarkus.micrometer.runtime.MicrometerRecorder;
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+
+public class PrometheusSimpleProcessor {
+
+    static final String REGISTRY_CLASS_NAME = "io.micrometer.prometheus.PrometheusMeterRegistry";
+    static final Class<?> REGISTRY_CLASS = MicrometerRecorder.getClassForName(REGISTRY_CLASS_NAME);
+
+    public static class PrometheusSimpleClientEnabled implements BooleanSupplier {
+        MicrometerConfig mConfig;
+        PrometheusSimpleConfig.PrometheusSimpleClientBuildConfig config;
+
+        @Override
+        public boolean getAsBoolean() {
+            return REGISTRY_CLASS != null
+                    && QuarkusClassLoader.isClassPresentAtRuntime(REGISTRY_CLASS_NAME)
+                    && mConfig.checkRegistryEnabledWithDefault(config);
+        }
+    }
+
+    public static class TraceEnabled implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return QuarkusClassLoader.isClassPresentAtRuntime("io.quarkus.opentelemetry.runtime.OpenTelemetryUtil");
+        }
+    }
+
+    @BuildStep(onlyIf = { PrometheusRegistryProcessor.TraceEnabled.class })
+    void registerOpentelemetryExemplarSamplerProvider(
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(OpentelemetryExemplarSamplerProvider.class)
+                .setUnremovable()
+                .build());
+    }
+
+    @BuildStep(onlyIfNot = { PrometheusRegistryProcessor.TraceEnabled.class })
+    void registerEmptyExamplarProvider(
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+        additionalBeans.produce(AdditionalBeanBuildItem.builder()
+                .addBeanClass(EmptyExemplarSamplerProvider.class)
+                .setUnremovable()
+                .build());
+    }
+
+    @BuildStep(onlyIf = PrometheusSimpleClientEnabled.class)
+    public void removeMicrometerExtensionBeans(BuildProducer<AdditionalBeanBuildItem> unnededBeans) {
+
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder()
+                .setRemovable()
+                .addBeanClasses(io.quarkus.micrometer.runtime.export.exemplars.OpentelemetryExemplarSamplerProvider.class,
+                        io.quarkus.micrometer.runtime.export.exemplars.EmptyExemplarSamplerProvider.class);
+
+        unnededBeans.produce(builder.build());
+    }
+
+    @BuildStep(onlyIf = PrometheusSimpleClientEnabled.class)
+    public MicrometerRegistryProviderBuildItem createPrometheusSimpleClientRegistry(
+            PrometheusSimpleConfig.PrometheusSimpleClientBuildConfig buildConfig,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+        // Add the general PrometheusSimpleClient Producer (config, naming conventions, .. )
+        AdditionalBeanBuildItem.Builder builder = AdditionalBeanBuildItem.builder()
+                .setUnremovable()
+                .addBeanClass(PrometheusSimpleMeterRegistryProvider.class);
+
+        if (buildConfig.defaultRegistry()) {
+            // Only add this Registry Producer if the default registry is enabled
+            builder.addBeanClass(ConditionalRegistryProducer.class);
+        }
+
+        additionalBeans.produce(builder.build());
+
+        // Include the PrometheusSimpleClientMeterRegistryProvider in a possible CompositeMeterRegistry
+        return new MicrometerRegistryProviderBuildItem(REGISTRY_CLASS);
+    }
+
+}

--- a/micrometer-registry-prometheus-simpleclient/pom.xml
+++ b/micrometer-registry-prometheus-simpleclient/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.micrometer.registry</groupId>
+        <artifactId>quarkus-micrometer-registry-parent</artifactId>
+        <version>399-SNAPSHOT</version>
+    </parent>
+
+    <!-- This is a simple extension that enables required dependencies:
+         Micrometer Extension AND the Micrometer Prometheus Registry library. -->
+
+    <artifactId>quarkus-micrometer-registry-prometheus-simpleclient-parent</artifactId>
+    <name>Quarkus - Micrometer Registry - Prometheus SimpleClient - Parent</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/micrometer-registry-prometheus-simpleclient/runtime/pom.xml
+++ b/micrometer-registry-prometheus-simpleclient/runtime/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.micrometer.registry</groupId>
+        <artifactId>quarkus-micrometer-registry-prometheus-simpleclient-parent</artifactId>
+        <version>399-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>quarkus-micrometer-registry-prometheus-simpleclient</artifactId>
+    <name>Quarkus - Micrometer Registry - Prometheus SimpleClient Runtime</name>
+    <description>Enable Prometheus support for Micrometer with the legacy v0.x client - Runtime</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-registry-prometheus</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${quarkus.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/ConditionalRegistryProducer.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/ConditionalRegistryProducer.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exemplars.ExemplarSampler;
+
+//@Singleton
+public class ConditionalRegistryProducer {
+
+    /**
+     * This producer is added as a bean by the Processor IFF the default registry
+     * instance has been enabled.
+     */
+    @Produces
+    @Singleton
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION + 100)
+    public PrometheusMeterRegistry registry(PrometheusConfig config,
+            CollectorRegistry collectorRegistry,
+            Optional<ExemplarSampler> exemplarSampler,
+            Clock clock) {
+        return new PrometheusMeterRegistry(config, collectorRegistry, clock, exemplarSampler.orElse(null));
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/PrometheusSimpleConfig.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/PrometheusSimpleConfig.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quarkus.micrometer.runtime.config.MicrometerConfig;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithParentName;
+
+public interface PrometheusSimpleConfig {
+    @ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+    @ConfigMapping(prefix = "quarkus.micrometer.export.prometheus.simpleclient")
+    public interface PrometheusSimpleClientBuildConfig extends MicrometerConfig.CapabilityEnabled {
+        /**
+         * Support for export to Prometheus SimpleClient.
+         * <p>
+         * Support for Prometheus Simple will be enabled if Micrometer
+         * support is enabled, the Prometheus Simple registry extension is enabled
+         * and either this value is true, or this value is unset and
+         * {@code quarkus.micrometer.registry-enabled-default} is true.
+         */
+        @Override
+        Optional<Boolean> enabled();
+
+        /**
+         * By default, this extension will create a Prometheus Simple MeterRegistry instance.
+         * <p>
+         * Use this attribute to veto the creation of the default Prometheus Simple MeterRegistry.
+         */
+        @WithDefault("true")
+        public boolean defaultRegistry();
+    }
+
+    /**
+     * Runtime configuration for Prometheus Simple
+     */
+    @ConfigRoot(phase = ConfigPhase.RUN_TIME)
+    @ConfigMapping(prefix = "quarkus.micrometer.export.prometheus.simpleclient")
+    public interface PrometheusSimpleClientRuntimeConfig {
+
+        // @formatter:off
+        /**
+         * Prometheus SimpleClient registry configuration properties.
+         *
+         *
+         * @asciidoclet
+         */
+        // @formatter:on
+        @WithParentName
+        Map<String, String> prometheusSimpleClient();
+    }
+
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/PrometheusSimpleMeterRegistryProvider.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/PrometheusSimpleMeterRegistryProvider.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient;
+
+import java.util.Map;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import jakarta.interceptor.Interceptor;
+
+import io.micrometer.prometheus.PrometheusConfig;
+import io.quarkiverse.micrometer.registry.prometheus.simpleclient.PrometheusSimpleConfig.PrometheusSimpleClientRuntimeConfig;
+import io.quarkus.micrometer.runtime.export.ConfigAdapter;
+
+/**
+ * @see ConditionalRegistryProducer
+ */
+@Singleton
+public class PrometheusSimpleMeterRegistryProvider {
+    static final String DEFAULT_REGISTRY = "quarkus.micrometer.export.prometheus.simpleclient.default-registry";
+    static final String PREFIX = "prometheus.";
+
+    static final String PUBLISH = "prometheus.publish";
+    static final String ENABLED = "prometheus.enabled";
+
+    @Produces
+    @Singleton
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION + 100)
+    public PrometheusConfig configure(PrometheusSimpleClientRuntimeConfig config) {
+        final Map<String, String> properties = ConfigAdapter.captureProperties(config.prometheusSimpleClient(), PREFIX);
+
+        // Special check: if publish is set, override the value of enabled
+        // Specifically, The prometheus registry must be enabled for this
+        // Provider to even be present. If this instance (at runtime) wants
+        // to prevent metrics from being published, then it would set
+        // quarkus.micrometer.export.prometheus.simpleclient.publish=false
+        if (properties.containsKey(PUBLISH)) {
+            properties.put(ENABLED, properties.get(PUBLISH));
+        }
+
+        return ConfigAdapter.validate(properties::get);
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/EmptyExemplarSamplerProvider.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/EmptyExemplarSamplerProvider.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars;
+
+import java.util.Optional;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.Interceptor;
+
+import io.prometheus.client.exemplars.ExemplarSampler;
+
+public class EmptyExemplarSamplerProvider {
+
+    @Produces
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION + 100)
+    public Optional<ExemplarSampler> exemplarSampler() {
+        return Optional.empty();
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/NoopOpenTelemetryExemplarContextUnwrapper.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/NoopOpenTelemetryExemplarContextUnwrapper.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars;
+
+import java.util.function.Function;
+
+import jakarta.enterprise.context.Dependent;
+
+import io.quarkus.micrometer.runtime.export.exemplars.OpenTelemetryContextUnwrapper;
+import io.vertx.core.Context;
+
+@Dependent
+public class NoopOpenTelemetryExemplarContextUnwrapper implements OpenTelemetryContextUnwrapper {
+
+    @Override
+    public <P, R> R executeInContext(Function<P, R> methodReference, P parameter, Context requestContext) {
+        return methodReference.apply(parameter);// pass through
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpenTelemetryContextUnwrapper.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpenTelemetryContextUnwrapper.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars;
+
+import java.util.function.Function;
+
+public interface OpenTelemetryContextUnwrapper {
+    /**
+     * Called when an HTTP server response has ended.
+     * Makes sure exemplars are produced because they have an OTel context.
+     *
+     * @param methodReference Ex: Sample stop method reference
+     * @param parameter The parameter to pass to the method
+     * @param requestContext The request context
+     * @param <P> The parameter type is a type of metric, ex: Timer
+     * @param <R> The return type of the method pointed by the methodReference
+     * @return The result of the method
+     */
+    <P, R> R executeInContext(Function<P, R> methodReference, P parameter, io.vertx.core.Context requestContext);
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpenTelemetryExemplarContextUnwrapper.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpenTelemetryExemplarContextUnwrapper.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars;
+
+import java.util.function.Function;
+
+import jakarta.enterprise.context.Dependent;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.quarkus.micrometer.runtime.export.exemplars.OpenTelemetryContextUnwrapper;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
+
+@Dependent
+public class OpenTelemetryExemplarContextUnwrapper implements OpenTelemetryContextUnwrapper {
+
+    @Override
+    public <P, R> R executeInContext(Function<P, R> methodReference, P parameter, io.vertx.core.Context requestContext) {
+        if (requestContext == null) {
+            return methodReference.apply(parameter);
+        }
+
+        Context newContext = QuarkusContextStorage.getContext(requestContext);
+
+        if (newContext == null) {
+            return methodReference.apply(parameter);
+        }
+
+        io.opentelemetry.context.Context oldContext = QuarkusContextStorage.INSTANCE.current();
+        try (Scope scope = QuarkusContextStorage.INSTANCE.attach(newContext)) {
+            return methodReference.apply(parameter);
+        }
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpentelemetryExemplarSamplerProvider.java
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/simpleclient/exemplars/OpentelemetryExemplarSamplerProvider.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.micrometer.registry.prometheus.simpleclient.exemplars;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.Interceptor;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.prometheus.client.exemplars.DefaultExemplarSampler;
+import io.prometheus.client.exemplars.ExemplarSampler;
+import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+import io.quarkus.opentelemetry.runtime.QuarkusContextStorage;
+
+public class OpentelemetryExemplarSamplerProvider {
+
+    @Produces
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION + 100)
+    public Optional<ExemplarSampler> exemplarSampler() {
+        return Optional.of(new DefaultExemplarSampler(new SpanContextSupplier() {
+            @Override
+            public String getTraceId() {
+                return get(SpanContext::getTraceId);
+            }
+
+            @Override
+            public String getSpanId() {
+                return get(SpanContext::getSpanId);
+            }
+
+            @Override
+            public boolean isSampled() {
+                return Boolean.TRUE.equals(get(SpanContext::isSampled));
+            }
+
+            private <T> T get(Function<SpanContext, T> valueExtractor) {
+                return Optional.ofNullable(Span.fromContextOrNull(QuarkusContextStorage.INSTANCE.current()))
+                        .map(Span::getSpanContext)
+                        .map(valueExtractor)
+                        .orElse(null);
+            }
+        }));
+    }
+}

--- a/micrometer-registry-prometheus-simpleclient/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/micrometer-registry-prometheus-simpleclient/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,15 @@
+name: "Micrometer Registry - Prometheus SimpleClient"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
+metadata:
+  keywords:
+  - "micrometer"
+  - "metrics"
+  - "metric"
+  - "prometheus"
+  - "monitoring"
+  guide: "https://quarkus.io/guides/micrometer"
+  categories:
+  - "observability"
+  status: "experimental"
+  config:
+  - "quarkus.micrometer."

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.22.1</quarkus.version>
+        <quarkus.version>3.22.3</quarkus.version>
 
         <skipTests>false</skipTests>
 
@@ -72,6 +72,7 @@
         <module>micrometer-registry-stackdriver</module>
         <module>micrometer-registry-statsd</module>
         <module>micrometer-registry-influx</module>
+        <module>micrometer-registry-prometheus-simpleclient</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Mitigates: https://github.com/quarkusio/quarkus/issues/47151

Make available, for an extended period of time, the legacy Prometheus SimpleClient (v0.x).