### PR TITLE
Simplify quarkus-snapshot workflow configuration

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -29,14 +29,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build:
     name: "Build against latest Quarkus snapshot"


### PR DESCRIPTION
Removed duplicated concurrency settings and default run shell from workflow.