### PR TITLE
Support Quarkus 3.39

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.38.2
+:quarkus-version: 3.39.1
 :quarkus-micrometer-registry-version: 3.6.0
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.33.3.1
+:quarkus-version: 3.38.2
 :quarkus-micrometer-registry-version: 3.6.0
 

--- a/integration-tests/micrometer-prometheus-v1-opentelemetry/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus-v1-opentelemetry/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -1,5 +1,7 @@
 package io.quarkus;
 
+import java.util.Optional;
+
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.Tags;
@@ -11,11 +13,10 @@ public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
 
     @Override
     public Tags contribute(Context context) {
+        Optional<HttpResponse> response = context.response();
         String value = "UNSET";
-        HttpResponse response = context.response();
-        // reset frames will not contain response
-        if (response != null) {
-            var headerValue = response.headers().get("foo-response");
+        if (response.isPresent()) {
+            var headerValue = response.get().headers().get("foo-response");
             if ((headerValue != null) && !headerValue.isEmpty()) {
                 value = headerValue;
             }

--- a/integration-tests/micrometer-prometheus-v1/src/main/java/io/quarkus/ResponseHeaderTag.java
+++ b/integration-tests/micrometer-prometheus-v1/src/main/java/io/quarkus/ResponseHeaderTag.java
@@ -1,5 +1,7 @@
 package io.quarkus;
 
+import java.util.Optional;
+
 import jakarta.inject.Singleton;
 
 import io.micrometer.core.instrument.Tags;
@@ -11,11 +13,10 @@ public class ResponseHeaderTag implements HttpServerMetricsTagsContributor {
 
     @Override
     public Tags contribute(Context context) {
+        Optional<HttpResponse> response = context.response();
         String value = "UNSET";
-        HttpResponse response = context.response();
-        // reset frames will not contain response
-        if (response != null) {
-            var headerValue = response.headers().get("foo-response");
+        if (response.isPresent()) {
+            var headerValue = response.get().headers().get("foo-response");
             if ((headerValue != null) && !headerValue.isEmpty()) {
                 value = headerValue;
             }

--- a/micrometer-registry-prometheus-v1/deployment/src/main/java/io/quarkiverse/micrometer/registry/deployment/binder/VertxBinderProcessor.java
+++ b/micrometer-registry-prometheus-v1/deployment/src/main/java/io/quarkiverse/micrometer/registry/deployment/binder/VertxBinderProcessor.java
@@ -47,7 +47,12 @@ public class VertxBinderProcessor {
     @BuildStep
     @Record(value = ExecutionTime.STATIC_INIT)
     VertxOptionsConsumerBuildItem build(VertxMeterBinderRecorder recorder) {
-        return new VertxOptionsConsumerBuildItem(recorder.setVertxMetricsOptions(), Interceptor.Priority.LIBRARY_AFTER);
+        // Core quarkus-micrometer registers its own consumer at the same priority with order key
+        // "micrometer.vertx.metrics", and both consumers overwrite the Vert.x MetricsOptions
+        // (last one applied wins). Consumers with equal priority run in order-key order, so this
+        // key must sort after core's for this extension's metrics implementation to win.
+        return new VertxOptionsConsumerBuildItem(recorder.setVertxMetricsOptions(), Interceptor.Priority.LIBRARY_AFTER,
+                "quarkiverse.micrometer.vertx.metrics");
     }
 
     @BuildStep

--- a/micrometer-registry-prometheus-v1/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/binder/vertx/VertxHttpServerMetrics.java
+++ b/micrometer-registry-prometheus-v1/runtime/src/main/java/io/quarkiverse/micrometer/registry/prometheus/binder/vertx/VertxHttpServerMetrics.java
@@ -3,6 +3,7 @@ package io.quarkiverse.micrometer.registry.prometheus.binder.vertx;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.jboss.logging.Logger;
@@ -182,7 +183,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
                     Outcome.CLIENT_ERROR.asTag(),
                     HttpCommonTags.STATUS_RESET);
 
-            allTags = additionalMetrics(requestMetric, null, allTags);
+            allTags = additionalMetrics(requestMetric, Optional.empty(), allTags);
 
             openTelemetryContextUnwrapper.executeInContext(
                     sample::stop,
@@ -214,7 +215,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
                             config.isServerSuppress4xxErrors()),
                     VertxMetricsTags.outcome(response),
                     HttpCommonTags.status(response.statusCode()));
-            allTags = additionalMetrics(requestMetric, response, allTags);
+            allTags = additionalMetrics(requestMetric, Optional.of(response), allTags);
 
             openTelemetryContextUnwrapper.executeInContext(
                     sample::stop,
@@ -227,7 +228,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
     /**
      * Make sure same tags are present for the same "http.server.requests" metric because it's defined in 2 places
      */
-    private Tags additionalMetrics(HttpRequestMetric requestMetric, HttpResponse response, Tags allTags) {
+    private Tags additionalMetrics(HttpRequestMetric requestMetric, Optional<HttpResponse> response, Tags allTags) {
         if (!httpServerMetricsTagsContributors.isEmpty()) {
             HttpServerMetricsTagsContributor.Context context = new DefaultContext(requestMetric.request(), response);
             for (int i = 0; i < httpServerMetricsTagsContributors.size(); i++) {
@@ -277,7 +278,7 @@ public class VertxHttpServerMetrics extends VertxTcpServerMetrics
     }
 
     private record DefaultContext(HttpServerRequest request,
-            HttpResponse response) implements HttpServerMetricsTagsContributor.Context {
+            Optional<HttpResponse> response) implements HttpServerMetricsTagsContributor.Context {
         @Override
         public <T> T requestContextLocalData(Object key) {
             return ((HttpServerRequestInternal) request).context().getLocal(key);

--- a/micrometer-registry-stackdriver/pom.xml
+++ b/micrometer-registry-stackdriver/pom.xml
@@ -12,7 +12,7 @@
     <name>Quarkus Micrometer Registry - Stackdriver - Parent</name>
     <description>Send metrics to Google Cloud Operations using Stackdriver</description>
     <properties>
-        <quarkus-google-cloud-services-bom.version>2.21.0</quarkus-google-cloud-services-bom.version>
+        <quarkus-google-cloud-services-bom.version>2.23.1</quarkus-google-cloud-services-bom.version>
     </properties>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.33.3.1</quarkus.version>
+        <quarkus.version>3.38.2</quarkus.version>
 
         <skipTests>false</skipTests>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.38.2</quarkus.version>
+        <quarkus.version>3.39.1</quarkus.version>
 
         <skipTests>false</skipTests>
 


### PR DESCRIPTION
Fixes #600.

Quarkus 3.38 made two changes that break `micrometer-registry-prometheus-v1`:

- quarkusio/quarkus#54828 replaced `VertxOptionsConsumerBuildItem(Consumer, int)` with a three-argument constructor that takes an order key. The old constructor is gone, so augmentation fails with a `NoSuchMethodError` on every build.
- `HttpServerMetricsTagsContributor.Context#response()` now returns `Optional<HttpResponse>`, so `VertxHttpServerMetrics.DefaultContext` no longer implements the interface. This is the compile error the ecosystem CI has been reporting since June.

Changes:

- Pass an order key (`quarkiverse.micrometer.vertx.metrics`) in `VertxBinderProcessor`, with a comment recording why the key must sort after core's: core micrometer's own consumer registers at the same priority, both overwrite the Vert.x `MetricsOptions`, and 3.38 orders equal-priority consumers by key — so the key string now decides which adapter wins. If you would rather make the override explicit, a priority above `LIBRARY_AFTER` would be ordering-proof; happy to change it.
- Thread `Optional<HttpResponse>` through `additionalMetrics`, matching core's `effectiveTags` shape (`Optional.empty()` from `requestReset`, `Optional.of` from `responseEnd`), so future syncs against core diff cleanly.
- Sync the two `ResponseHeaderTag` integration-test copies with their Quarkus core counterpart.
- Bump `quarkus.version` from 3.31.4 to 3.38.2 (`attributes.adoc` follows the property).

Note on compatibility: this raises the extension's floor to Quarkus 3.38 — the three-argument build-item constructor and the `Optional`-returning `Context#response()` do not exist earlier, so pre-3.38 users of the next release would fail at augmentation. Worth a release note.

Not addressed here (possible follow-up): the forked `VertxHttpServerMetrics` lags core 3.38's behaviour — core now shares one `http.server.active.requests` gauge across server instances (the management interface's second registration is otherwise silently swallowed) and tags it with `server.port`. This PR ports only what 3.38 breaks at compile time.

_Issue analyzed and PR created with the help of Claude Code._