### PR TITLE
Upgrade Quarkus to 3.33.3.1

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:quarkus-version: 3.31.4
+:quarkus-version: 3.33.3.1
 :quarkus-micrometer-registry-version: 3.5.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.31.4</quarkus.version>
+        <quarkus.version>3.33.3.1</quarkus.version>
 
         <skipTests>false</skipTests>
 
         <assertj.version>3.27.7</assertj.version>
-        <mockito.version>5.21.0</mockito.version>
+        <mockito.version>5.23.0</mockito.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
This is based on the latest 3.33.x LTS version. I will create a maintenance branch for it, after release. 